### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE.TXT
+++ b/LICENSE.TXT
@@ -10,7 +10,7 @@ FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 details.
 
 You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 The full text of the GPL is provided in the COPYING file.
 
@@ -41,4 +41,4 @@ FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 details.
 
 You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/vmware-au-se-sqlfireweb/src/main/webapp/LICENSE.txt
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/LICENSE.txt
@@ -10,25 +10,25 @@ FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 details.
 
 You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 The full text of the GPL is provided in the COPYING file.
 
 SQLFire*Web is a translation of phpmyadmin, which is licensed as noted below:
 
 Copyright (C) 1998-2000
-ÊÊÊÊTobias Ratschiller <tobias_at_ratschiller.com>
+ï¿½ï¿½ï¿½ï¿½Tobias Ratschiller <tobias_at_ratschiller.com>
 
 Copyright (C) 2001-2013
-ÊÊÊÊMarc Delisle <marc_at_infomarc.info>
-ÊÊÊÊOlivier MŸller <om_at_omnis.ch>
-ÊÊÊÊRobin Johnson <robbat2_at_users.sourceforge.net>
-ÊÊÊÊAlexander M. Turek <me_at_derrabus.de>
-ÊÊÊÊMichal Cihar <michal_at_cihar.com>
-ÊÊÊÊGarvin Hicking <me_at_supergarv.de>
-ÊÊÊÊMichael Keck <mkkeck_at_users.sourceforge.net>
-ÊÊÊÊSebastian Mendel <cybot_tm_at_users.sourceforge.net>
-ÊÊÊÊ[check documentation for more details]
+ï¿½ï¿½ï¿½ï¿½Marc Delisle <marc_at_infomarc.info>
+ï¿½ï¿½ï¿½ï¿½Olivier Mï¿½ller <om_at_omnis.ch>
+ï¿½ï¿½ï¿½ï¿½Robin Johnson <robbat2_at_users.sourceforge.net>
+ï¿½ï¿½ï¿½ï¿½Alexander M. Turek <me_at_derrabus.de>
+ï¿½ï¿½ï¿½ï¿½Michal Cihar <michal_at_cihar.com>
+ï¿½ï¿½ï¿½ï¿½Garvin Hicking <me_at_supergarv.de>
+ï¿½ï¿½ï¿½ï¿½Michael Keck <mkkeck_at_users.sourceforge.net>
+ï¿½ï¿½ï¿½ï¿½Sebastian Mendel <cybot_tm_at_users.sourceforge.net>
+ï¿½ï¿½ï¿½ï¿½[check documentation for more details]
 
 
 This program is free software; you can redistribute it and/or modify it under
@@ -41,4 +41,4 @@ FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more
 details.
 
 You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/async.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/async.jsp
@@ -21,7 +21,7 @@
     pageEncoding="ISO-8859-1"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">

--- a/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/conmap.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/conmap.jsp
@@ -21,7 +21,7 @@
     pageEncoding="ISO-8859-1"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">

--- a/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/constraints.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/constraints.jsp
@@ -21,7 +21,7 @@
     pageEncoding="ISO-8859-1"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">

--- a/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/create-index.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/create-index.jsp
@@ -20,7 +20,7 @@
 <%@ page language="java" contentType="text/html; charset=ISO-8859-1" pageEncoding="ISO-8859-1"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">

--- a/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/create-table.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/create-table.jsp
@@ -20,7 +20,7 @@
 <%@ page language="java" contentType="text/html; charset=ISO-8859-1" pageEncoding="ISO-8859-1"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">

--- a/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/diskstores.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/diskstores.jsp
@@ -21,7 +21,7 @@
     pageEncoding="ISO-8859-1"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">

--- a/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/displayquery.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/displayquery.jsp
@@ -21,7 +21,7 @@
     pageEncoding="ISO-8859-1"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">

--- a/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/error.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/error.jsp
@@ -21,7 +21,7 @@
     pageEncoding="ISO-8859-1"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">

--- a/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/gatewayreceivers.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/gatewayreceivers.jsp
@@ -21,7 +21,7 @@
     pageEncoding="ISO-8859-1"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">

--- a/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/gatewaysenders.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/gatewaysenders.jsp
@@ -21,7 +21,7 @@
     pageEncoding="ISO-8859-1"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">

--- a/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/history.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/history.jsp
@@ -22,7 +22,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">

--- a/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/indexes.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/indexes.jsp
@@ -21,7 +21,7 @@
     pageEncoding="ISO-8859-1"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">

--- a/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/loginpage.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/loginpage.jsp
@@ -23,7 +23,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <style type="text/css">

--- a/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/main.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/main.jsp
@@ -20,7 +20,7 @@
 <%@ page language="java" contentType="text/html; charset=ISO-8859-1"
     pageEncoding="ISO-8859-1"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />

--- a/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/members.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/members.jsp
@@ -21,7 +21,7 @@
     pageEncoding="ISO-8859-1"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">

--- a/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/preferences.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/preferences.jsp
@@ -21,7 +21,7 @@
     pageEncoding="ISO-8859-1"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">

--- a/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/procs.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/procs.jsp
@@ -21,7 +21,7 @@
     pageEncoding="ISO-8859-1"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">

--- a/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/query.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/query.jsp
@@ -23,7 +23,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <style type="text/css">

--- a/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/reports.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/reports.jsp
@@ -21,7 +21,7 @@
     pageEncoding="ISO-8859-1"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">

--- a/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/tables.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/tables.jsp
@@ -22,7 +22,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">

--- a/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/toolbar.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/toolbar.jsp
@@ -25,7 +25,7 @@
   <img class="icon" src="../themes/original/img/b_props.png" width="16" height="16" alt="SQLFire Preferences" />
   Preferences
 </a>&nbsp; | &nbsp;
-<a href="http://pubs.vmware.com/vfabric5/index.jsp?topic=/com.vmware.vfabric.sqlfire.1.0/getting_started/book_intro.html&lp=default" title="SQLFire Documentation" target="_top">
+<a href="https://pubs.vmware.com/vfabric5/index.jsp?topic=/com.vmware.vfabric.sqlfire.1.0/getting_started/book_intro.html&lp=default" title="SQLFire Documentation" target="_top">
   <img class="icon" src="../themes/original/img/b_docs.png" width="16" height="16" alt="SQLFire doco" />
   SQLFire Documentation
 </a>&nbsp; | &nbsp;

--- a/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/triggers.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/triggers.jsp
@@ -21,7 +21,7 @@
     pageEncoding="ISO-8859-1"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">

--- a/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/types.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/types.jsp
@@ -21,7 +21,7 @@
     pageEncoding="ISO-8859-1"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">

--- a/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/views.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/WEB-INF/jsp/views.jsp
@@ -21,7 +21,7 @@
     pageEncoding="ISO-8859-1"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">

--- a/vmware-au-se-sqlfireweb/src/main/webapp/navigation.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/navigation.jsp
@@ -20,7 +20,7 @@
 <%@ page language="java" contentType="text/html; charset=ISO-8859-1"
     pageEncoding="ISO-8859-1"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">

--- a/vmware-au-se-sqlfireweb/src/main/webapp/welcome.jsp
+++ b/vmware-au-se-sqlfireweb/src/main/webapp/welcome.jsp
@@ -22,7 +22,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/fmt" prefix="fmt"%>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "https://www.w3.org/TR/html4/loose.dtd">
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
@@ -42,7 +42,7 @@
   <img class="icon" src="./themes/original/img/b_props.png" width="16" height="16" alt="SQLFire Preferences" />
   Preferences
 </a>&nbsp; | &nbsp;
-<a href="http://pubs.vmware.com/vfabric53/index.jsp?topic=/com.vmware.vfabric.sqlfire.1.1/about_users_guide.html" title="SQLFire Documentation" target="_top">
+<a href="https://pubs.vmware.com/vfabric53/index.jsp?topic=/com.vmware.vfabric.sqlfire.1.1/about_users_guide.html" title="SQLFire Documentation" target="_top">
   <img class="icon" src="./themes/original/img/b_docs.png" width="16" height="16" alt="SQLFire doco" />
   SQLFire Documentation
 </a>&nbsp; | &nbsp;


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.w3.org/TR/html4/loose.dtd (ReadTimeoutException) with 25 occurrences migrated to:  
  https://www.w3.org/TR/html4/loose.dtd ([https](https://www.w3.org/TR/html4/loose.dtd) result ReadTimeoutException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.gnu.org/licenses/ with 4 occurrences migrated to:  
  https://www.gnu.org/licenses/ ([https](https://www.gnu.org/licenses/) result 200).
* http://pubs.vmware.com/vfabric5/index.jsp?topic=/com.vmware.vfabric.sqlfire.1.0/getting_started/book_intro.html&lp=default with 1 occurrences migrated to:  
  https://pubs.vmware.com/vfabric5/index.jsp?topic=/com.vmware.vfabric.sqlfire.1.0/getting_started/book_intro.html&lp=default ([https](https://pubs.vmware.com/vfabric5/index.jsp?topic=/com.vmware.vfabric.sqlfire.1.0/getting_started/book_intro.html&lp=default) result 301).
* http://pubs.vmware.com/vfabric53/index.jsp?topic=/com.vmware.vfabric.sqlfire.1.1/about_users_guide.html with 1 occurrences migrated to:  
  https://pubs.vmware.com/vfabric53/index.jsp?topic=/com.vmware.vfabric.sqlfire.1.1/about_users_guide.html ([https](https://pubs.vmware.com/vfabric53/index.jsp?topic=/com.vmware.vfabric.sqlfire.1.1/about_users_guide.html) result 301).

# Ignored
These URLs were intentionally ignored.

* http://java.sun.com/jsp/jstl/core with 25 occurrences
* http://java.sun.com/jsp/jstl/fmt with 23 occurrences
* http://java.sun.com/jsp/jstl/functions with 3 occurrences
* http://www.springframework.org/tags/form with 2 occurrences